### PR TITLE
Google sign flow service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules/
 platforms/
 plugins/
+www/lib

--- a/karma.conf
+++ b/karma.conf
@@ -9,6 +9,7 @@ module.exports = function(config){
     files : [
         'node_modules/angular/angular.js', // require angular in karma env.
         'node_modules/angular-mocks/angular-mocks.js', // mock some angular modules;
+        'node_modules/ng-cordova/dist/ng-cordova-mocks.min.js',
         'www/js/**/*.js',
     ],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "karma-jasmine": "^0.3.6",
     "shelljs": "^0.3.0",
     "protractor": "^2.1.0",
-    "http-server": "^0.6.1"
+    "http-server": "^0.6.1",
+    "cordova": "^5.4.0"
   },
   "cordovaPlugins": [
     "cordova-plugin-device",

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -33,4 +33,12 @@ angular
     var isAppEnvironmentValid = function() {
       return $window.cordova !== undefined && $window.cordova !== null;
     };
+
+    var getRedirectURI = function(options) {
+      var redirectURI = "http://localhost/callback";
+      if (options !== undefined && options.hasOwnProperty('redirect_uri')) {
+        redirectURI = options.redirect_uri;
+      }
+      return redirectURI;
+    };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -59,6 +59,7 @@ angular
               reject("Problem authenticating");
               return;
             }
+            resolve(token);
           }, function(event) {
             reject("The authentication was canceled");
           }

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -2,4 +2,16 @@ angular
   .module('libs.oauth.google', ['libs.oauth.utils'])
   .factory('$googleOAuth', ['$window', '$http', '$q', '$OAuthUtils',
            function($window, $http, $q, $OAuthUtils) {
+
+    var getOAuth2URL= function(clientId, appScope, redirectURI) {
+      return (
+        'https://accounts.google.com/o/oauth2/auth?client_id=' +
+        clientId +
+        '&redirect_uri=' +
+        redirectURI +
+        '&scope=' +
+        appScope.join(" ") +
+        '&approval_prompt=force&response_type=token'
+      );
+    };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -29,4 +29,8 @@ angular
         expiresIn: parseInt(parameters.expires_in)
       };
     };
+
+    var isAppEnvironmentValid = function() {
+      return $window.cordova !== undefined && $window.cordova !== null;
+    };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -44,6 +44,10 @@ angular
 
     var auth = function(clientId, appScope, options) {
       return $q(function(resolve, reject) {
+        if (!isAppEnvironmentValid()) {
+          reject("App is running in invalid environment");
+          return;
+        }
       });
     };
     return {

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -45,5 +45,6 @@ angular
       getOAuth2URL: getOAuth2URL,
       parseOAuth2Response: parseOAuth2Response,
       isAppEnvironmentValid: isAppEnvironmentValid,
+      getRedirectURI: getRedirectURI,
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -66,11 +66,15 @@ angular
         )
       });
     };
+
     return {
+      // Helper functions
       getOAuth2URL: getOAuth2URL,
       parseOAuth2Response: parseOAuth2Response,
       isAppEnvironmentValid: isAppEnvironmentValid,
       getRedirectURI: getRedirectURI,
+
+      // Exposed Main Function
       auth: auth
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -16,7 +16,7 @@ angular
     };
 
     var parseOAuth2Response = function(url) {
-      if (url.split('#').length != 2) {
+      if (url.split('#').length !== 2) {
         return null;
       }
       var parameters = $OAuthUtils.parseResponseParameters(url.split('#')[1]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -44,5 +44,6 @@ angular
     return {
       getOAuth2URL: getOAuth2URL,
       parseOAuth2Response: parseOAuth2Response,
+      isAppEnvironmentValid: isAppEnvironmentValid,
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -42,5 +42,6 @@ angular
       return redirectURI;
     };
     return {
+      getOAuth2URL: getOAuth2URL,
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -43,5 +43,6 @@ angular
     };
     return {
       getOAuth2URL: getOAuth2URL,
+      parseOAuth2Response: parseOAuth2Response,
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -75,6 +75,28 @@ angular
       getRedirectURI: getRedirectURI,
 
       // Exposed Main Function
+     /*
+     * @param {string} clientId
+     * Identifies the client that is making the request. The value passed in this parameter must exactly match the value shown in the Google Developers Console.(including the http or https scheme, case, and trailing '/').
+     *
+     * @param {string} appScope
+     * Identifies the Google API access that your application is requesting.The values passed in this parameter inform the consent screen that is shown to the user.To see the available scopes for all Google APIs, visit https://developers.google.com/apis-explorer/#p/
+     *
+     * @param {object} options
+     * You can customize `redirectURL` in options. It's optional.
+     *
+     * @return {promise}
+     * You can get accessToken/tokenType/expiresIn in success callback, or reason in failure callback.
+     *
+     * @example
+     * $googleOAuth.auth('your-client-id.apps.googleusercontent.com', ['email']).then(
+     *  function(data) {
+     *    console.log(data.accessToken, data.tokenType, data.expiresIn);
+     *  }, function(error_message) {
+     *    console.log(error_message)
+     *  }
+     * )
+     */
       auth: auth
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -1,0 +1,5 @@
+angular
+  .module('libs.oauth.google', ['libs.oauth.utils'])
+  .factory('$googleOAuth', ['$window', '$http', '$q', '$OAuthUtils',
+           function($window, $http, $q, $OAuthUtils) {
+  }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -14,4 +14,19 @@ angular
         '&approval_prompt=force&response_type=token'
       );
     };
+
+    var parseOAuth2Response = function(url) {
+      if (url.split('#').length != 2) {
+        return null;
+      }
+      var parameters = $OAuthUtils.parseResponseParameters(url.split('#')[1]);
+      if (parameters.access_token === undefined || parameters.access_token === null) {
+        return null;
+      }
+      return {
+        accessToken: parameters.access_token,
+        tokenType: parameters.token_type,
+        expiresIn: parseInt(parameters.expires_in)
+      };
+    };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -41,10 +41,16 @@ angular
       }
       return redirectURI;
     };
+
+    var auth = function(clientId, appScope, options) {
+      return $q(function(resolve, reject) {
+      });
+    };
     return {
       getOAuth2URL: getOAuth2URL,
       parseOAuth2Response: parseOAuth2Response,
       isAppEnvironmentValid: isAppEnvironmentValid,
       getRedirectURI: getRedirectURI,
+      auth: auth
     };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -54,6 +54,11 @@ angular
 
         $OAuthUtils.browseUntil(authURL, redirectURL).then(
           function(event) {
+            var token = parseOAuth2Response(event.url);
+            if (!token) {
+              reject("Problem authenticating");
+              return;
+            }
           }, function(event) {
             reject("The authentication was canceled");
           }

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -41,4 +41,6 @@ angular
       }
       return redirectURI;
     };
+    return {
+    };
   }]);

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -3,7 +3,7 @@ angular
   .factory('$googleOAuth', ['$window', '$http', '$q', '$OAuthUtils',
            function($window, $http, $q, $OAuthUtils) {
 
-    var getOAuth2URL= function(clientId, appScope, redirectURI) {
+    var _getOAuth2URL = function(clientId, appScope, redirectURI) {
       return (
         'https://accounts.google.com/o/oauth2/auth?client_id=' +
         clientId +
@@ -15,7 +15,7 @@ angular
       );
     };
 
-    var parseOAuth2Response = function(url) {
+    var _parseOAuth2Response = function(url) {
       if (url.split('#').length !== 2) {
         return null;
       }
@@ -30,11 +30,11 @@ angular
       };
     };
 
-    var isAppEnvironmentValid = function() {
+    var _isAppEnvironmentValid = function() {
       return $window.cordova !== undefined && $window.cordova !== null;
     };
 
-    var getRedirectURI = function(options) {
+    var _getRedirectURI = function(options) {
       var redirectURI = "http://localhost/callback";
       if (options !== undefined && options.hasOwnProperty('redirect_uri')) {
         redirectURI = options.redirect_uri;
@@ -44,17 +44,17 @@ angular
 
     var auth = function(clientId, appScope, options) {
       return $q(function(resolve, reject) {
-        if (!isAppEnvironmentValid()) {
+        if (!_isAppEnvironmentValid()) {
           reject("App is running in invalid environment");
           return;
         }
 
-        var redirectURL = getRedirectURI(options);
-        var authURL = getOAuth2URL(clientId, appScope, redirectURL);
+        var redirectURL = _getRedirectURI(options);
+        var authURL = _getOAuth2URL(clientId, appScope, redirectURL);
 
         $OAuthUtils.browseUntil(authURL, redirectURL).then(
           function(event) {
-            var token = parseOAuth2Response(event.url);
+            var token = _parseOAuth2Response(event.url);
             if (!token) {
               reject("Problem authenticating");
               return;
@@ -69,10 +69,10 @@ angular
 
     return {
       // Helper functions
-      getOAuth2URL: getOAuth2URL,
-      parseOAuth2Response: parseOAuth2Response,
-      isAppEnvironmentValid: isAppEnvironmentValid,
-      getRedirectURI: getRedirectURI,
+      _getOAuth2URL: _getOAuth2URL,
+      _parseOAuth2Response: _parseOAuth2Response,
+      _isAppEnvironmentValid: _isAppEnvironmentValid,
+      _getRedirectURI: _getRedirectURI,
 
       // Exposed Main Function
      /*

--- a/www/js/libs/oauth/google.js
+++ b/www/js/libs/oauth/google.js
@@ -48,6 +48,16 @@ angular
           reject("App is running in invalid environment");
           return;
         }
+
+        var redirectURL = getRedirectURI(options);
+        var authURL = getOAuth2URL(clientId, appScope, redirectURL);
+
+        $OAuthUtils.browseUntil(authURL, redirectURL).then(
+          function(event) {
+          }, function(event) {
+            reject("The authentication was canceled");
+          }
+        )
       });
     };
     return {

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -56,4 +56,11 @@ describe('libs.oauth.google module', function() {
       expect($googleOAuth.isAppEnvironmentValid()).toBeTruthy();
     });
   });
+
+
+  describe('getRedirectURI', function() {
+    it("should get http://localhost/callback as default uri", function() {
+      expect($googleOAuth.getRedirectURI()).toEqual('http://localhost/callback');
+    });
+  })
 });

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -43,4 +43,17 @@ describe('libs.oauth.google module', function() {
       expect(parsed.expiresIn).toEqual(1);
     });
   });
+
+
+  describe('isAppEnvironmentValid', function() {
+    it("should return false if cordova is not in env", function() {
+      $window.cordova = null;
+      expect($googleOAuth.isAppEnvironmentValid()).toBeFalsy();
+    });
+
+    it("should return true if cordova is in env", function() {
+      $window.cordova = {};
+      expect($googleOAuth.isAppEnvironmentValid()).toBeTruthy();
+    });
+  });
 });

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('libs.oauth.google module', function() {
+  var $OAuthUtils, $window, $googleOAuth, $q, $rootScope;
+  var authDeferred;
+
+  beforeEach(module('libs.oauth.google'));
+  beforeEach(inject(function(_$OAuthUtils_, _$googleOAuth_, _$window_, _$q_, _$rootScope_){
+    $OAuthUtils = _$OAuthUtils_;
+    $googleOAuth = _$googleOAuth_;
+    $q = _$q_;
+    $rootScope = _$rootScope_;
+    $window = _$window_;
+    $window.cordova = jasmine.createSpyObj('cordova', ['require']);
+    authDeferred = $q.defer();
+    spyOn($OAuthUtils, 'browseUntil').and.returnValue(authDeferred.promise);
+  }));
+});

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -23,4 +23,24 @@ describe('libs.oauth.google module', function() {
       );
     })
   });
+
+  describe('parseOAuth2Response', function() {
+    it('should find empty access token and then return empty object', function(){
+      spyOn($OAuthUtils, 'parseResponseParameters').and.returnValue({});
+      expect($googleOAuth.parseOAuth2Response('#')).toEqual(null);
+      expect($googleOAuth.parseOAuth2Response('')).toEqual(null);
+    });
+
+    it('should find access_token and other related fields', function() {
+      spyOn($OAuthUtils, 'parseResponseParameters').and.returnValue({
+        access_token: 'token',
+        token_type: 'type',
+        expires_in: '1'
+      });
+      var parsed = $googleOAuth.parseOAuth2Response('#');
+      expect(parsed.accessToken).toEqual('token');
+      expect(parsed.tokenType).toEqual('type');
+      expect(parsed.expiresIn).toEqual(1);
+    });
+  });
 });

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -46,6 +46,15 @@ describe('libs.oauth.google module', function() {
 
 
   describe('auth', function() {
+    it('should be able to reject in wrong env', function() {
+      $window.cordova = null;
+      $googleOAuth.auth('client@google.com', ['email']).then(function(data) {
+        throw data;
+      }, function(data) {
+        expect(data).toEqual('App is running in invalid environment');
+      });
+      $rootScope.$apply();
+    });
   });
 
 

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -18,7 +18,7 @@ describe('libs.oauth.google module', function() {
 
   describe('getOAuth2URL', function() {
     it('should build oauth2 url', function() {
-      expect($googleOAuth.getOAuth2URL('clientId', ['scope1', 'scope2'], 'http://localhost')).toEqual(
+      expect($googleOAuth._getOAuth2URL('clientId', ['scope1', 'scope2'], 'http://localhost')).toEqual(
         'https://accounts.google.com/o/oauth2/auth?client_id=clientId&redirect_uri=http://localhost&scope=scope1 scope2&approval_prompt=force&response_type=token'
       );
     })
@@ -27,8 +27,8 @@ describe('libs.oauth.google module', function() {
   describe('parseOAuth2Response', function() {
     it('should find empty access token and then return empty object', function(){
       spyOn($OAuthUtils, 'parseResponseParameters').and.returnValue({});
-      expect($googleOAuth.parseOAuth2Response('#')).toEqual(null);
-      expect($googleOAuth.parseOAuth2Response('')).toEqual(null);
+      expect($googleOAuth._parseOAuth2Response('#')).toEqual(null);
+      expect($googleOAuth._parseOAuth2Response('')).toEqual(null);
     });
 
     it('should find access_token and other related fields', function() {
@@ -37,7 +37,7 @@ describe('libs.oauth.google module', function() {
         token_type: 'type',
         expires_in: '1'
       });
-      var parsed = $googleOAuth.parseOAuth2Response('#');
+      var parsed = $googleOAuth._parseOAuth2Response('#');
       expect(parsed.accessToken).toEqual('token');
       expect(parsed.tokenType).toEqual('type');
       expect(parsed.expiresIn).toEqual(1);
@@ -97,19 +97,19 @@ describe('libs.oauth.google module', function() {
   describe('isAppEnvironmentValid', function() {
     it("should return false if cordova is not in env", function() {
       $window.cordova = null;
-      expect($googleOAuth.isAppEnvironmentValid()).toBeFalsy();
+      expect($googleOAuth._isAppEnvironmentValid()).toBeFalsy();
     });
 
     it("should return true if cordova is in env", function() {
       $window.cordova = {};
-      expect($googleOAuth.isAppEnvironmentValid()).toBeTruthy();
+      expect($googleOAuth._isAppEnvironmentValid()).toBeTruthy();
     });
   });
 
 
   describe('getRedirectURI', function() {
     it("should get http://localhost/callback as default uri", function() {
-      expect($googleOAuth.getRedirectURI()).toEqual('http://localhost/callback');
+      expect($googleOAuth._getRedirectURI()).toEqual('http://localhost/callback');
     });
   })
 });

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -45,6 +45,10 @@ describe('libs.oauth.google module', function() {
   });
 
 
+  describe('auth', function() {
+  });
+
+
   describe('isAppEnvironmentValid', function() {
     it("should return false if cordova is not in env", function() {
       $window.cordova = null;

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -46,6 +46,17 @@ describe('libs.oauth.google module', function() {
 
 
   describe('auth', function() {
+
+    it('should be able to reject on calceling flow', function() {
+      authDeferred.reject({});
+      $googleOAuth.auth('client@google.com', ['email']).then(function(data) {
+        throw data;
+      }, function(data) {
+        expect(data).toEqual('The authentication was canceled');
+      });
+      $rootScope.$apply();
+    });
+
     it('should be able to reject in wrong env', function() {
       $window.cordova = null;
       $googleOAuth.auth('client@google.com', ['email']).then(function(data) {

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -15,4 +15,12 @@ describe('libs.oauth.google module', function() {
     authDeferred = $q.defer();
     spyOn($OAuthUtils, 'browseUntil').and.returnValue(authDeferred.promise);
   }));
+
+  describe('getOAuth2URL', function() {
+    it('should build oauth2 url', function() {
+      expect($googleOAuth.getOAuth2URL('clientId', ['scope1', 'scope2'], 'http://localhost')).toEqual(
+        'https://accounts.google.com/o/oauth2/auth?client_id=clientId&redirect_uri=http://localhost&scope=scope1 scope2&approval_prompt=force&response_type=token'
+      );
+    })
+  });
 });

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -47,6 +47,18 @@ describe('libs.oauth.google module', function() {
 
   describe('auth', function() {
 
+    it('should be able to reject on parsing error', function() {
+      authDeferred.resolve({
+        url: 'http://localhost/callback', // without any parameters
+      });
+      $googleOAuth.auth('client@google.com', ['email']).then(function(data) {
+        throw data;
+      }, function(data) {
+        expect(data).toEqual('Problem authenticating');
+      });
+      $rootScope.$apply();
+    });
+
     it('should be able to reject on calceling flow', function() {
       authDeferred.reject({});
       $googleOAuth.auth('client@google.com', ['email']).then(function(data) {

--- a/www/js/libs/oauth/google_test.js
+++ b/www/js/libs/oauth/google_test.js
@@ -46,6 +46,19 @@ describe('libs.oauth.google module', function() {
 
 
   describe('auth', function() {
+    it('should fetch access_token', function() {
+      authDeferred.resolve({
+        url: 'http://localhost/callback#access_token=token&token_type=type&expires_in=1'
+      });
+      $googleOAuth.auth('client@google.com', ['email']).then(function(data) {
+        expect(data.accessToken).toEqual('token');
+        expect(data.tokenType).toEqual('type');
+        expect(data.expiresIn).toEqual(1);
+      }, function(data) {
+        throw data;
+      });
+      $rootScope.$apply();
+    });
 
     it('should be able to reject on parsing error', function() {
       authDeferred.resolve({

--- a/www/js/libs/oauth/utils.js
+++ b/www/js/libs/oauth/utils.js
@@ -68,21 +68,27 @@ angular.module("libs.oauth.utils", [])
                 }
             },
 
-            authenticateInNewWindow: function(url, options) {
-              var df = $q.defer();
-              var browserRef = $window.open(url, '_blank', options);
+            browseUntil: function(start, end) {
+              return $q(function(resolve, reject) {
+                var options = 'location=no,clearsessioncache=yes,clearcache=yes';
+                var browserRef = $window.open(start, '_blank', options);
 
-              browserRef.addEventListener('loadstart', function(event){
-                browserRef.removeEventListener("exit", function(event){});
-                browserRef.close();
-                df.resolve(event);
+                browserRef.addEventListener('loadstart', onLoadStart);
+                browserRef.addEventListener('exit', onExit);
+
+                function onLoadStart(event) {
+                  if ((event.url).indexOf(end) !== 0) {
+                    return; // Ignore
+                  }
+                  browserRef.removeEventListener("exit", function(event){});
+                  browserRef.close();
+                  resolve(event);
+                }
+
+                function onExit(event) {
+                  reject(event);
+                }
               });
-
-              browserRef.addEventListener('exit', function(event) {
-                df.reject(event);
-              });
-
-              return df.promise;
             }
 
         };

--- a/www/js/libs/oauth/utils_test.js
+++ b/www/js/libs/oauth/utils_test.js
@@ -53,13 +53,13 @@ describe('libs.oauth.utils module', function() {
     });
   });
 
-  describe('authenticateInNewWindow', function() {
+  describe('browseUntil', function() {
     it('should open window to start authentication flow', inject(function($window) {
       spyOn($window, 'open').and.callFake(function() {return {
         addEventListener: function(event, cb) {}
       };});
-      $OAuthUtils.authenticateInNewWindow('http://localhost', 'options=blah');
-      expect($window.open).toHaveBeenCalledWith('http://localhost', '_blank', 'options=blah');
+      $OAuthUtils.browseUntil('http://localhost', 'options=blah');
+      expect($window.open).toHaveBeenCalledWith('http://localhost', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
     }));
   });
 });


### PR DESCRIPTION
This pull request introduce `$googleOAuth.auth` method:

``` javascript
$googleOAuth.auth("CLIENT_ID_HERE", ["email"]).then(function(result) {
    console.log(data.accessToken, data.tokenType, data.expiresIn);
}, function(error) {
    console.log("Error -> " + error);
});
```

We can handle login in success callback and not login in failure callback.
